### PR TITLE
Fallback to LLM client as a library

### DIFF
--- a/bot/llm_client.py
+++ b/bot/llm_client.py
@@ -1,7 +1,6 @@
 import os
 
 from dotenv import load_dotenv
-from fastapi import FastAPI
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import SystemMessage
 from langchain_core.output_parsers.base import BaseOutputParser
@@ -10,21 +9,22 @@ from langchain_core.prompts.base import BasePromptTemplate
 from langchain_core.runnables.base import RunnableSequence
 from langchain_openai import ChatOpenAI
 from langchain.prompts import HumanMessagePromptTemplate
-from langserve import add_routes
-import uvicorn
+from langchain.schema import StrOutputParser
 
 API_KEY_ENV_VAR_NAME: str = "OPENAI_API_KEY"
+TEXT_FIELD_NAME: str = "text"
 
 SYSTEM_MESSAGE: str = (
     "You are a professional proofreader, you are here to help me with rewriting texts. "
-    "I will provide you texts and I would like you to review and rewrite them, and fix "
-    "any style, spelling, grammar, or punctuation errors. Once you have finished reviewing, "
-    "provide me with corrected text."
+    "I will provide you texts and I would like you to review and rewrite them in proper English, "
+    "and fix any style, spelling, grammar, or punctuation errors. Once you have finished reviewing, "
+    "provide me with corrected text without any prefix or suffix."
 )
 prompt: BasePromptTemplate = ChatPromptTemplate.from_messages(
     [
         SystemMessage(content=SYSTEM_MESSAGE),
         HumanMessagePromptTemplate.from_template(
+            # Do not rename {text} field, it is used by the LLMClient.rewrite method.
             "The text to proofread, rewrite, and fix is: {text}"
         ),
     ]
@@ -38,25 +38,23 @@ class LLMClient:
         """Initializes the LLMClient object."""
         self.llm: BaseChatModel = ChatOpenAI(openai_api_key=api_key)
 
+    def rewrite(self, text: str) -> str:
+        """Rewrites the given text."""
+        output_parser: BaseOutputParser = StrOutputParser()
+        chain: RunnableSequence = prompt | self.llm | output_parser
+        return chain.invoke({TEXT_FIELD_NAME: text})
+
 
 if __name__ == "__main__":
-    # If you want to run this script, you need to set the OPENAI_API_KEY environment variable.
-    # Create .env file in the same directory as this script and add the following line:
-    # OPENAI_API_KEY=your-api-key
+    # load_dotenv() is in use only for local development and testing.
     load_dotenv()
+
     api_key: str = os.getenv(API_KEY_ENV_VAR_NAME)
     if api_key is None:
         raise ValueError(f"Environment variable {API_KEY_ENV_VAR_NAME} is not set.")
 
     client = LLMClient(api_key=api_key)
-    app = FastAPI(
-        title="Proofreading and Rewriting API",
-        version="1.0",
-        description="A simple API for proofreading and rewriting texts.",
+    text: str = (
+        "Snow weather in New York make me very surprise, so much white and cold!"
     )
-    add_routes(
-        app,
-        prompt | client.llm,
-        path="/rewrite",
-    )
-    uvicorn.run(app, port=18029)
+    print(client.rewrite(text))

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ charset-normalizer==3.3.2
 click==8.1.7
 dataclasses-json==0.6.4
 distro==1.9.0
-fastapi==0.109.2
 frozenlist==1.4.1
 greenlet==3.0.3
 h11==0.14.0
@@ -23,7 +22,6 @@ langchain==0.1.5
 langchain-community==0.0.17
 langchain-core==0.1.18
 langchain-openai==0.0.5
-langserve==0.0.41
 langsmith==0.0.86
 marshmallow==3.20.2
 multidict==6.0.5


### PR DESCRIPTION
Unfortunately, langserve do not satisfy extra API key we need for auth. 
Hence, provide LLM client as a library instead of an API server.